### PR TITLE
ENH: Add a `PyCapsule` calss

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# GitHub syntax highlighting
+pixi.lock linguist-language=YAML
+

--- a/examples/bindc/pyclass_opaque/cpython/meson.build
+++ b/examples/bindc/pyclass_opaque/cpython/meson.build
@@ -1,0 +1,20 @@
+project('pyclass_bindc', 'c', 'fortran',
+        version : '0.1',
+        default_options : ['warning_level=2',
+                           'buildtype=debug',
+                           'debug=true',
+                          ])
+
+py_mod = import('python')
+py3 = py_mod.find_installation('python3')
+py3_dep = py3.dependency()
+message(py3.path())
+message(py3.get_install_dir())
+
+# Python Class Representation
+py3.extension_module('point',
+           # 'vec.f90',
+           'point.c',
+           'pointcapsule.c',
+           dependencies : py3_dep,
+           install : true)

--- a/examples/bindc/pyclass_opaque/cpython/point.c
+++ b/examples/bindc/pyclass_opaque/cpython/point.c
@@ -1,0 +1,40 @@
+/* C file: point.c */
+#include "point.h"
+
+/* Function to create a new Point */
+Point* create_point(double x, double y) {
+    Point* p = (Point*) malloc(sizeof(Point));
+    if (p != NULL) {
+        p->x = x;
+        p->y = y;
+    }
+    return p;
+}
+
+/* Function to delete a Point */
+void destroy_point(Point* p) {
+    free(p);
+}
+
+/* Function to move the Point */
+void move_point(Point* p, double dx, double dy) {
+    if (p != NULL) {
+        p->x += dx;
+        p->y += dy;
+    }
+}
+
+/* Function to get the coordinates of the Point */
+double get_x(const Point* p) {
+    return p->x;
+}
+double get_y(const Point* p) {
+    return p->y;
+}
+/* Function to set the coordinates of the Point */
+void set_x(Point* p, double x) {
+    p->x = x;
+}
+void set_y(Point* p, double y) {
+    p->y = y;
+}

--- a/examples/bindc/pyclass_opaque/cpython/point.h
+++ b/examples/bindc/pyclass_opaque/cpython/point.h
@@ -1,0 +1,19 @@
+#ifndef POINT_H_
+#define POINT_H_
+
+#include "stddef.h"
+#include "stdlib.h"
+
+typedef struct {
+    double x, y;
+} Point;
+
+Point* create_point(double x, double y);
+void destroy_point(Point* p);
+void move_point(Point* p, double dx, double dy);
+double get_x(const Point* p);
+void set_x(Point* p, double x);
+double get_y(const Point* p);
+void set_y(Point* p, double y);
+
+#endif // POINT_H_

--- a/examples/bindc/pyclass_opaque/cpython/pointcapsule.c
+++ b/examples/bindc/pyclass_opaque/cpython/pointcapsule.c
@@ -1,0 +1,168 @@
+#ifndef PY_SSIZE_T_CLEAN
+#define PY_SSIZE_T_CLEAN
+#include <stdio.h>
+#endif /* PY_SSIZE_T_CLEAN */
+
+#include "Python.h"
+#include "structmember.h"
+#include "point.h"
+
+#include <Python.h>
+
+/* Destructor for the Python capsule */
+void point_capsule_destructor(PyObject* capsule) {
+    Point* p = (Point*) PyCapsule_GetPointer(capsule, "point._Point");
+    destroy_point(p);
+}
+
+// Python wrapper for the Point class
+typedef struct {
+    PyObject_HEAD
+    PyObject* capsule; // Capsule containing the Point pointer
+} PyPoint;
+
+// Methods of the Point class
+static void PyPoint_dealloc(PyPoint* self) {
+    /* Decrement the reference count of the capsule */
+    Py_XDECREF(self->capsule);
+    Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+static PyObject* PyPoint_new(PyTypeObject* type, PyObject* args, PyObject* kwds) {
+    PyPoint* self;
+
+    self = (PyPoint*)type->tp_alloc(type, 0);
+    if (self != NULL) {
+        double x, y;
+        if (!PyArg_ParseTuple(args, "dd", &x, &y)) {
+            Py_DECREF(self);
+            return NULL;
+        }
+        Point* p = create_point(x, y);
+        self->capsule = PyCapsule_New(p, "point._Point", point_capsule_destructor);
+        if (self->capsule == NULL) {
+            Py_DECREF(self);
+            return NULL;
+        }
+    }
+
+    return (PyObject*)self;
+}
+
+// Getter for x
+static PyObject* PyPoint_getx(PyPoint* self, void* closure) {
+    Point* p = (Point*) PyCapsule_GetPointer(self->capsule, "point._Point");
+    if (!p) {
+        PyErr_SetString(PyExc_RuntimeError, "The point is invalid.");
+        return NULL;
+    }
+    double x = get_x(p);
+    return PyFloat_FromDouble(x);
+}
+
+// Setter for x
+static int PyPoint_setx(PyPoint* self, PyObject* value, void* closure) {
+    if (value == NULL) {
+        PyErr_SetString(PyExc_TypeError, "Cannot delete the x attribute");
+        return -1;
+    }
+    if (!PyFloat_Check(value)) {
+        PyErr_SetString(PyExc_TypeError, "The x attribute value must be a float");
+        return -1;
+    }
+    Point* p = (Point*) PyCapsule_GetPointer(self->capsule, "point._Point");
+    if (!p) {
+        PyErr_SetString(PyExc_RuntimeError, "The point is invalid.");
+        return -1;
+    }
+    double x = PyFloat_AsDouble(value);
+    set_x(p, x);
+    return 0;
+}
+
+// Getter for y
+static PyObject* PyPoint_gety(PyPoint* self, void* closure) {
+    Point* p = (Point*) PyCapsule_GetPointer(self->capsule, "point._Point");
+    if (!p) {
+        PyErr_SetString(PyExc_RuntimeError, "The point is invalid.");
+        return NULL;
+    }
+    double y = get_y(p);
+    return PyFloat_FromDouble(y);
+}
+
+// Setter for y
+static int PyPoint_sety(PyPoint* self, PyObject* value, void* closure) {
+    if (value == NULL) {
+        PyErr_SetString(PyExc_TypeError, "Cannot delete the y attribute");
+        return -1;
+    }
+    if (!PyFloat_Check(value)) {
+        PyErr_SetString(PyExc_TypeError, "The y attribute value must be a float");
+        return -1;
+    }
+    Point* p = (Point*) PyCapsule_GetPointer(self->capsule, "point._Point");
+    if (!p) {
+        PyErr_SetString(PyExc_RuntimeError, "The point is invalid.");
+        return -1;
+    }
+    double y = PyFloat_AsDouble(value);
+    set_y(p, y);
+    return 0;
+}
+
+
+// Define getters and setters
+static PyGetSetDef PyPoint_getsetters[] = {
+    {"x", (getter)PyPoint_getx, (setter)PyPoint_setx, "x coordinate", NULL},
+    {"y", (getter)PyPoint_gety, (setter)PyPoint_sety, "y coordinate", NULL},
+    {NULL}  /* Sentinel */
+};
+
+// Define the Python type object for Point
+static PyTypeObject PyPointType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = "point.Point",             /* tp_name */
+    .tp_basicsize = sizeof(PyPoint),           /* tp_basicsize */
+    .tp_dealloc = (destructor)PyPoint_dealloc, /* tp_dealloc */
+    .tp_flags = Py_TPFLAGS_DEFAULT,        /* tp_flags */
+    .tp_doc = "Point objects",           /* tp_doc */
+    .tp_getset = PyPoint_getsetters,        /* tp_getset */
+    .tp_new = PyPoint_new               /* tp_new */
+};
+
+// Module method definitions
+static PyMethodDef point_methods[] = {
+    // Method definitions would go here, if there are any global functions
+    {NULL, NULL, 0, NULL}  /* Sentinel */
+};
+
+// Module definition
+static struct PyModuleDef pointmodule = {
+    PyModuleDef_HEAD_INIT,
+    "point",   /* name of module */
+    "Module that provides a Point object.",  /* module documentation, may be NULL */
+    -1,        /* size of per-interpreter state of the module */
+    point_methods
+};
+
+// Module initialization function
+PyMODINIT_FUNC PyInit_point(void) {
+    PyObject* m;
+
+    if (PyType_Ready(&PyPointType) < 0)
+        return NULL;
+
+    m = PyModule_Create(&pointmodule);
+    if (m == NULL)
+        return NULL;
+
+    Py_INCREF(&PyPointType);
+    if (PyModule_AddObject(m, "Point", (PyObject *)&PyPointType) < 0) {
+        Py_DECREF(&PyPointType);
+        Py_DECREF(m);
+        return NULL;
+    }
+
+    return m;
+}

--- a/examples/bindc/pyclass_opaque/cpython/readme.org
+++ b/examples/bindc/pyclass_opaque/cpython/readme.org
@@ -1,0 +1,11 @@
+* About
+** Usage
+#+begin_src bash
+meson setup bbdir
+meson compile -C bbdir
+python -c "from bbdir import point; aa = point.Point(1,2); print(aa.x); aa.x = 1.2; print(aa.x)"
+1.0
+1.2
+#+end_src
+
+Look into generating a wrapper in Fortran which would then be manipulated via pointers on the C side.

--- a/examples/bindc/pyclass_opaque/cwrappers.f90
+++ b/examples/bindc/pyclass_opaque/cwrappers.f90
@@ -1,0 +1,79 @@
+! cwrappers.f90
+! C interoperable wrappers
+module c_wrappers
+    use, intrinsic :: iso_c_binding, only: c_ptr, c_double, c_null_ptr, &
+         c_loc, c_associated, c_f_pointer
+    use point_module
+    implicit none
+
+    contains
+
+    ! Wrapper for creating a new point
+    function c_new_point(x, y) bind(C, name="c_new_point")
+        real(c_double), value :: x, y
+        type(c_ptr) :: c_new_point
+        type(Point), pointer :: p
+        integer :: stat
+
+        call create_point(x, y, p, stat)
+        if (stat /= 0) then
+            print *, "Allocation failed"
+            c_new_point = C_NULL_PTR
+            return
+        endif
+
+        c_new_point = c_loc(p)
+    end function c_new_point
+
+    ! Wrapper to set the x value of a point
+    subroutine c_set_x(p_cptr, x) bind(c, name='c_set_x')
+        type(c_ptr), intent(in) :: p_cptr
+        real(c_double), intent(in), value :: x
+        type(Point), pointer :: p
+
+        call c_f_pointer(p_cptr, p)  ! This associates the C pointer with the Fortran pointer
+        call set_x(p, x)             ! Now you can call the Fortran subroutine to set the x value
+    end subroutine c_set_x
+
+    ! Wrapper to get the x value of a point
+    function c_get_x(p_cptr) bind(c, name='c_get_x') result(x)
+        type(c_ptr), intent(in) :: p_cptr
+        real(c_double) :: x
+        type(Point), pointer :: p
+
+        call c_f_pointer(p_cptr, p)
+        x = get_x(p)
+    end function c_get_x
+
+    ! Wrapper to set the y value of a point
+    subroutine c_set_y(p_cptr, y) bind(c, name='c_set_y')
+        type(c_ptr), intent(in) :: p_cptr
+        real(c_double), intent(in), value :: y
+        type(Point), pointer :: p
+
+        call c_f_pointer(p_cptr, p)
+        call set_y(p, y)
+    end subroutine c_set_y
+
+    ! Wrapper to get the y value of a point
+    function c_get_y(p_cptr) bind(c, name='c_get_y') result(y)
+        type(c_ptr), intent(in) :: p_cptr
+        real(c_double) :: y
+        type(Point), pointer :: p
+
+        call c_f_pointer(p_cptr, p)
+        y = get_y(p)
+    end function c_get_y
+
+    ! Wrapper for deallocating a point
+    subroutine c_delete_point(p_cptr) bind(c, name='c_delete_point')
+        type(c_ptr), intent(inout) :: p_cptr
+        type(Point), pointer :: p
+
+        if (.not. c_associated(p_cptr)) return
+        call c_f_pointer(p_cptr, p)
+        call destroy_point(p)
+        p_cptr = c_null_ptr
+    end subroutine c_delete_point
+
+end module c_wrappers

--- a/examples/bindc/pyclass_opaque/cwrappers.f90
+++ b/examples/bindc/pyclass_opaque/cwrappers.f90
@@ -1,79 +1,79 @@
 ! cwrappers.f90
 ! C interoperable wrappers
 module c_wrappers
-    use, intrinsic :: iso_c_binding, only: c_ptr, c_double, c_null_ptr, &
-         c_loc, c_associated, c_f_pointer
-    use point_module
-    implicit none
+   use, intrinsic :: iso_c_binding, only: c_ptr, c_double, c_null_ptr, &
+                                                                             c_loc, c_associated, c_f_pointer
+   use point_module
+   implicit none
 
-    contains
+contains
 
-    ! Wrapper for creating a new point
-    function c_new_point(x, y) bind(C, name="c_new_point")
-        real(c_double), value :: x, y
-        type(c_ptr) :: c_new_point
-        type(Point), pointer :: p
-        integer :: stat
+   ! Wrapper for creating a new point
+   function c_new_point(x, y) bind(C, name="c_new_point")
+      real(c_double), value :: x, y
+      type(c_ptr) :: c_new_point
+      type(Point), pointer :: p
+      integer :: stat
 
-        call create_point(x, y, p, stat)
-        if (stat /= 0) then
-            print *, "Allocation failed"
-            c_new_point = C_NULL_PTR
-            return
-        endif
+      call create_point(x, y, p, stat)
+      if (stat /= 0) then
+         print *, "Allocation failed"
+         c_new_point = C_NULL_PTR
+         return
+      end if
 
-        c_new_point = c_loc(p)
-    end function c_new_point
+      c_new_point = c_loc(p)
+   end function c_new_point
 
-    ! Wrapper to set the x value of a point
-    subroutine c_set_x(p_cptr, x) bind(c, name='c_set_x')
-        type(c_ptr), intent(in) :: p_cptr
-        real(c_double), intent(in), value :: x
-        type(Point), pointer :: p
+   ! Wrapper to set the x value of a point
+   subroutine c_set_x(p_cptr, x) bind(c, name='c_set_x')
+      type(c_ptr), intent(in) :: p_cptr
+      real(c_double), intent(in), value :: x
+      type(Point), pointer :: p
 
-        call c_f_pointer(p_cptr, p)  ! This associates the C pointer with the Fortran pointer
-        call set_x(p, x)             ! Now you can call the Fortran subroutine to set the x value
-    end subroutine c_set_x
+      call c_f_pointer(p_cptr, p)
+      call set_x(p, x)
+   end subroutine c_set_x
 
-    ! Wrapper to get the x value of a point
-    function c_get_x(p_cptr) bind(c, name='c_get_x') result(x)
-        type(c_ptr), intent(in) :: p_cptr
-        real(c_double) :: x
-        type(Point), pointer :: p
+   ! Wrapper to get the x value of a point
+   function c_get_x(p_cptr) bind(c, name='c_get_x') result(x)
+      type(c_ptr), intent(in) :: p_cptr
+      real(c_double) :: x
+      type(Point), pointer :: p
 
-        call c_f_pointer(p_cptr, p)
-        x = get_x(p)
-    end function c_get_x
+      call c_f_pointer(p_cptr, p)
+      x = get_x(p)
+   end function c_get_x
 
-    ! Wrapper to set the y value of a point
-    subroutine c_set_y(p_cptr, y) bind(c, name='c_set_y')
-        type(c_ptr), intent(in) :: p_cptr
-        real(c_double), intent(in), value :: y
-        type(Point), pointer :: p
+   ! Wrapper to set the y value of a point
+   subroutine c_set_y(p_cptr, y) bind(c, name='c_set_y')
+      type(c_ptr), intent(in) :: p_cptr
+      real(c_double), intent(in), value :: y
+      type(Point), pointer :: p
 
-        call c_f_pointer(p_cptr, p)
-        call set_y(p, y)
-    end subroutine c_set_y
+      call c_f_pointer(p_cptr, p)
+      call set_y(p, y)
+   end subroutine c_set_y
 
-    ! Wrapper to get the y value of a point
-    function c_get_y(p_cptr) bind(c, name='c_get_y') result(y)
-        type(c_ptr), intent(in) :: p_cptr
-        real(c_double) :: y
-        type(Point), pointer :: p
+   ! Wrapper to get the y value of a point
+   function c_get_y(p_cptr) bind(c, name='c_get_y') result(y)
+      type(c_ptr), intent(in) :: p_cptr
+      real(c_double) :: y
+      type(Point), pointer :: p
 
-        call c_f_pointer(p_cptr, p)
-        y = get_y(p)
-    end function c_get_y
+      call c_f_pointer(p_cptr, p)
+      y = get_y(p)
+   end function c_get_y
 
-    ! Wrapper for deallocating a point
-    subroutine c_delete_point(p_cptr) bind(c, name='c_delete_point')
-        type(c_ptr), intent(inout) :: p_cptr
-        type(Point), pointer :: p
+   ! Wrapper for deallocating a point
+   subroutine c_delete_point(p_cptr) bind(c, name='c_delete_point')
+      type(c_ptr), intent(inout) :: p_cptr
+      type(Point), pointer :: p
 
-        if (.not. c_associated(p_cptr)) return
-        call c_f_pointer(p_cptr, p)
-        call destroy_point(p)
-        p_cptr = c_null_ptr
-    end subroutine c_delete_point
+      if (.not. c_associated(p_cptr)) return
+      call c_f_pointer(p_cptr, p)
+      call destroy_point(p)
+      p_cptr = c_null_ptr
+   end subroutine c_delete_point
 
 end module c_wrappers

--- a/examples/bindc/pyclass_opaque/f_cwrapper_test.f90
+++ b/examples/bindc/pyclass_opaque/f_cwrapper_test.f90
@@ -1,0 +1,53 @@
+program test_point
+    use, intrinsic :: iso_c_binding
+    use point_module
+    use c_wrappers
+    implicit none
+
+    type(c_ptr) :: p_cptr
+    real(c_double) :: x, y
+    real(c_double) :: retrieved_x, retrieved_y
+
+    ! Test creating a new point
+    x = 1.0_c_double
+    y = 2.0_c_double
+    p_cptr = c_new_point(x, y)
+    if (.not. c_associated(p_cptr)) then
+        print *, "Error creating new point"
+        stop
+    end if
+
+    ! Retrieve the x and y values using the Fortran function
+    retrieved_x = c_get_x(p_cptr)
+    retrieved_y = c_get_y(p_cptr)
+    print *, "Point created: (", retrieved_x, ", ", retrieved_y, ")"
+
+    ! Test setting and getting the x value
+    call c_set_x(p_cptr, 3.0_c_double)
+    retrieved_x = c_get_x(p_cptr)
+    if (retrieved_x /= 3.0_c_double) then
+        print *, "Error with set_x or get_x"
+        stop
+    end if
+    print *, "X value set and retrieved correctly."
+
+    ! Test setting and getting the y value
+    call c_set_y(p_cptr, 4.0_c_double)
+    retrieved_y = c_get_y(p_cptr)
+    if (retrieved_y /= 4.0_c_double) then
+        print *, "Error with set_y or get_y"
+        stop
+    end if
+    print *, "Y value set and retrieved correctly."
+
+    ! Test deleting the point
+    call c_delete_point(p_cptr)
+    if (c_associated(p_cptr)) then
+        print *, "Error deleting point"
+        stop
+    end if
+    print *, "Point deleted successfully."
+
+    print *, "All tests passed successfully."
+
+end program test_point

--- a/examples/bindc/pyclass_opaque/f_cwrapper_test.f90
+++ b/examples/bindc/pyclass_opaque/f_cwrapper_test.f90
@@ -1,53 +1,53 @@
 program test_point
-    use, intrinsic :: iso_c_binding
-    use point_module
-    use c_wrappers
-    implicit none
+   use, intrinsic :: iso_c_binding
+   use point_module
+   use c_wrappers
+   implicit none
 
-    type(c_ptr) :: p_cptr
-    real(c_double) :: x, y
-    real(c_double) :: retrieved_x, retrieved_y
+   type(c_ptr) :: p_cptr
+   real(c_double) :: x, y
+   real(c_double) :: retrieved_x, retrieved_y
 
-    ! Test creating a new point
-    x = 1.0_c_double
-    y = 2.0_c_double
-    p_cptr = c_new_point(x, y)
-    if (.not. c_associated(p_cptr)) then
-        print *, "Error creating new point"
-        stop
-    end if
+   ! Test creating a new point
+   x = 1.0_c_double
+   y = 2.0_c_double
+   p_cptr = c_new_point(x, y)
+   if (.not. c_associated(p_cptr)) then
+      print *, "Error creating new point"
+      stop
+   end if
 
-    ! Retrieve the x and y values using the Fortran function
-    retrieved_x = c_get_x(p_cptr)
-    retrieved_y = c_get_y(p_cptr)
-    print *, "Point created: (", retrieved_x, ", ", retrieved_y, ")"
+   ! Retrieve the x and y values using the Fortran function
+   retrieved_x = c_get_x(p_cptr)
+   retrieved_y = c_get_y(p_cptr)
+   print *, "Point created: (", retrieved_x, ", ", retrieved_y, ")"
 
-    ! Test setting and getting the x value
-    call c_set_x(p_cptr, 3.0_c_double)
-    retrieved_x = c_get_x(p_cptr)
-    if (retrieved_x /= 3.0_c_double) then
-        print *, "Error with set_x or get_x"
-        stop
-    end if
-    print *, "X value set and retrieved correctly."
+   ! Test setting and getting the x value
+   call c_set_x(p_cptr, 3.0_c_double)
+   retrieved_x = c_get_x(p_cptr)
+   if (retrieved_x /= 3.0_c_double) then
+      print *, "Error with set_x or get_x"
+      stop
+   end if
+   print *, "X value set and retrieved correctly."
 
-    ! Test setting and getting the y value
-    call c_set_y(p_cptr, 4.0_c_double)
-    retrieved_y = c_get_y(p_cptr)
-    if (retrieved_y /= 4.0_c_double) then
-        print *, "Error with set_y or get_y"
-        stop
-    end if
-    print *, "Y value set and retrieved correctly."
+   ! Test setting and getting the y value
+   call c_set_y(p_cptr, 4.0_c_double)
+   retrieved_y = c_get_y(p_cptr)
+   if (retrieved_y /= 4.0_c_double) then
+      print *, "Error with set_y or get_y"
+      stop
+   end if
+   print *, "Y value set and retrieved correctly."
 
-    ! Test deleting the point
-    call c_delete_point(p_cptr)
-    if (c_associated(p_cptr)) then
-        print *, "Error deleting point"
-        stop
-    end if
-    print *, "Point deleted successfully."
+   ! Test deleting the point
+   call c_delete_point(p_cptr)
+   if (c_associated(p_cptr)) then
+      print *, "Error deleting point"
+      stop
+   end if
+   print *, "Point deleted successfully."
 
-    print *, "All tests passed successfully."
+   print *, "All tests passed successfully."
 
 end program test_point

--- a/examples/bindc/pyclass_opaque/ftest.f90
+++ b/examples/bindc/pyclass_opaque/ftest.f90
@@ -1,0 +1,46 @@
+program test_point_module
+    use point_module
+    implicit none
+
+    type(Point), pointer :: pt
+    real(8) :: x_val, y_val
+    integer :: alloc_status
+
+    ! Test creating a new point
+    call create_point(1.0d0, 2.0d0, pt, alloc_status)
+
+    if (.not. associated(pt)) then
+        print *, "Point creation failed with status ", alloc_status
+        stop
+    else
+        print *, "Point created: (", pt%x, ", ", pt%y, ")"
+    end if
+
+    ! Test modifying the point's x and y values
+    call set_x(pt, 5.0d0)
+    call set_y(pt, 10.0d0)
+
+    ! Test getting the point's x and y values
+    x_val = get_x(pt)
+    y_val = get_y(pt)
+
+    print *, "After setting new values:"
+    print *, "x =", x_val, "y =", y_val
+
+    ! Check if the values are as expected
+    if (x_val == 5.0d0 .and. y_val == 10.0d0) then
+        print *, "Point values updated correctly."
+    else
+        print *, "Error in updating point values."
+    end if
+
+    ! Test destroying the point
+    call destroy_point(pt)
+
+    if (.not. associated(pt)) then
+        print *, "Point destroyed successfully."
+    else
+        print *, "Error in destroying point."
+    end if
+
+end program test_point_module

--- a/examples/bindc/pyclass_opaque/ftest.f90
+++ b/examples/bindc/pyclass_opaque/ftest.f90
@@ -1,46 +1,46 @@
 program test_point_module
-    use point_module
-    implicit none
+   use point_module
+   implicit none
 
-    type(Point), pointer :: pt
-    real(8) :: x_val, y_val
-    integer :: alloc_status
+   type(Point), pointer :: pt
+   real(8) :: x_val, y_val
+   integer :: alloc_status
 
-    ! Test creating a new point
-    call create_point(1.0d0, 2.0d0, pt, alloc_status)
+   ! Test creating a new point
+   call create_point(1.0d0, 2.0d0, pt, alloc_status)
 
-    if (.not. associated(pt)) then
-        print *, "Point creation failed with status ", alloc_status
-        stop
-    else
-        print *, "Point created: (", pt%x, ", ", pt%y, ")"
-    end if
+   if (.not. associated(pt)) then
+      print *, "Point creation failed with status ", alloc_status
+      stop
+   else
+      print *, "Point created: (", pt%x, ", ", pt%y, ")"
+   end if
 
-    ! Test modifying the point's x and y values
-    call set_x(pt, 5.0d0)
-    call set_y(pt, 10.0d0)
+   ! Test modifying the point's x and y values
+   call set_x(pt, 5.0d0)
+   call set_y(pt, 10.0d0)
 
-    ! Test getting the point's x and y values
-    x_val = get_x(pt)
-    y_val = get_y(pt)
+   ! Test getting the point's x and y values
+   x_val = get_x(pt)
+   y_val = get_y(pt)
 
-    print *, "After setting new values:"
-    print *, "x =", x_val, "y =", y_val
+   print *, "After setting new values:"
+   print *, "x =", x_val, "y =", y_val
 
-    ! Check if the values are as expected
-    if (x_val == 5.0d0 .and. y_val == 10.0d0) then
-        print *, "Point values updated correctly."
-    else
-        print *, "Error in updating point values."
-    end if
+   ! Check if the values are as expected
+   if (x_val == 5.0d0 .and. y_val == 10.0d0) then
+      print *, "Point values updated correctly."
+   else
+      print *, "Error in updating point values."
+   end if
 
-    ! Test destroying the point
-    call destroy_point(pt)
+   ! Test destroying the point
+   call destroy_point(pt)
 
-    if (.not. associated(pt)) then
-        print *, "Point destroyed successfully."
-    else
-        print *, "Error in destroying point."
-    end if
+   if (.not. associated(pt)) then
+      print *, "Point destroyed successfully."
+   else
+      print *, "Error in destroying point."
+   end if
 
 end program test_point_module

--- a/examples/bindc/pyclass_opaque/meson.build
+++ b/examples/bindc/pyclass_opaque/meson.build
@@ -1,0 +1,38 @@
+project('pyclass_bindc', 'c', 'fortran',
+        version : '0.1',
+        default_options : ['warning_level=2',
+                           'buildtype=debug',
+                           'debug=true',
+                          ])
+
+py_mod = import('python')
+py3 = py_mod.find_installation('python3')
+py3_dep = py3.dependency()
+message(py3.path())
+message(py3.get_install_dir())
+
+# Python Class Representation
+py3.extension_module('point',
+           'point.f90',
+           'cwrappers.f90',
+           # 'point.c',
+           'pointcapsule.c',
+           dependencies : py3_dep,
+           install : true)
+
+executable('ftest',
+           'ftest.f90',
+           'point.f90',
+           install : true)
+
+executable('ftest_cwrap',
+           'f_cwrapper_test.f90',
+           'point.f90',
+           'cwrappers.f90',
+           install : true)
+
+executable('ctestf',
+           'testc.c',
+           'point.f90',
+           'cwrappers.f90',
+           install : true)

--- a/examples/bindc/pyclass_opaque/point.f90
+++ b/examples/bindc/pyclass_opaque/point.f90
@@ -1,62 +1,62 @@
 module point_module
-    implicit none
+   implicit none
 
-    type :: Point
-        real(8) :: x
-        real(8) :: y
-    end type Point
+   type :: Point
+      real(8) :: x
+      real(8) :: y
+   end type Point
 
 contains
 
-    subroutine create_point(x, y, p, alloc_stat)
-        real(8), intent(in) :: x, y
-        type(Point), pointer :: p
-        integer, intent(out), optional :: alloc_stat
+   subroutine create_point(x, y, p, alloc_stat)
+      real(8), intent(in) :: x, y
+      type(Point), pointer :: p
+      integer, intent(out), optional :: alloc_stat
 
-        allocate(p, stat=alloc_stat)
-        if (present(alloc_stat) .and. alloc_stat /= 0) then
-            return
-        endif
-        p%x = x
-        p%y = y
-    end subroutine create_point
+      allocate (p, stat=alloc_stat)
+      if (present(alloc_stat) .and. alloc_stat /= 0) then
+         return
+      end if
+      p%x = x
+      p%y = y
+   end subroutine create_point
 
-    subroutine destroy_point(p)
-        type(Point), pointer :: p
-        if (associated(p)) then
-           deallocate(p)
-           p => null()  ! This line nullifies the Fortran pointer
-        end if
-    end subroutine destroy_point
+   subroutine destroy_point(p)
+      type(Point), pointer :: p
+      if (associated(p)) then
+         deallocate (p)
+         p => null()  ! This line nullifies the Fortran pointer
+      end if
+   end subroutine destroy_point
 
-    function get_x(p) result(x_value)
-        type(Point), intent(in) :: p
-        real(8) :: x_value
+   function get_x(p) result(x_value)
+      type(Point), intent(in) :: p
+      real(8) :: x_value
 
-        x_value = p%x
-    end function get_x
+      x_value = p%x
+   end function get_x
 
-    subroutine set_x(p, x)
-        type(Point), intent(inout) :: p
-        real(8), intent(in) :: x
+   subroutine set_x(p, x)
+      type(Point), intent(inout) :: p
+      real(8), intent(in) :: x
 
-        p%x = x
-    end subroutine set_x
+      p%x = x
+   end subroutine set_x
 
-    function get_y(p) result(y_value)
-        type(Point), intent(in) :: p
-        real(8) :: y_value
+   function get_y(p) result(y_value)
+      type(Point), intent(in) :: p
+      real(8) :: y_value
 
-        y_value = p%y
-    end function get_y
+      y_value = p%y
+   end function get_y
 
-    subroutine set_y(p, y)
-        type(Point), intent(inout) :: p
-        real(8), intent(in) :: y
+   subroutine set_y(p, y)
+      type(Point), intent(inout) :: p
+      real(8), intent(in) :: y
 
-        p%y = y
-    end subroutine set_y
+      p%y = y
+   end subroutine set_y
 
-    ! Additional subroutines for move_point, etc. would go here.
+   ! Additional subroutines for move_point, etc. would go here.
 
 end module point_module

--- a/examples/bindc/pyclass_opaque/point.f90
+++ b/examples/bindc/pyclass_opaque/point.f90
@@ -1,0 +1,62 @@
+module point_module
+    implicit none
+
+    type :: Point
+        real(8) :: x
+        real(8) :: y
+    end type Point
+
+contains
+
+    subroutine create_point(x, y, p, alloc_stat)
+        real(8), intent(in) :: x, y
+        type(Point), pointer :: p
+        integer, intent(out), optional :: alloc_stat
+
+        allocate(p, stat=alloc_stat)
+        if (present(alloc_stat) .and. alloc_stat /= 0) then
+            return
+        endif
+        p%x = x
+        p%y = y
+    end subroutine create_point
+
+    subroutine destroy_point(p)
+        type(Point), pointer :: p
+        if (associated(p)) then
+           deallocate(p)
+           p => null()  ! This line nullifies the Fortran pointer
+        end if
+    end subroutine destroy_point
+
+    function get_x(p) result(x_value)
+        type(Point), intent(in) :: p
+        real(8) :: x_value
+
+        x_value = p%x
+    end function get_x
+
+    subroutine set_x(p, x)
+        type(Point), intent(inout) :: p
+        real(8), intent(in) :: x
+
+        p%x = x
+    end subroutine set_x
+
+    function get_y(p) result(y_value)
+        type(Point), intent(in) :: p
+        real(8) :: y_value
+
+        y_value = p%y
+    end function get_y
+
+    subroutine set_y(p, y)
+        type(Point), intent(inout) :: p
+        real(8), intent(in) :: y
+
+        p%y = y
+    end subroutine set_y
+
+    ! Additional subroutines for move_point, etc. would go here.
+
+end module point_module

--- a/examples/bindc/pyclass_opaque/point.h
+++ b/examples/bindc/pyclass_opaque/point.h
@@ -1,0 +1,13 @@
+#ifndef VECF_H_
+#define VECF_H_
+
+#include<stdio.h>
+#include<stdlib.h>
+
+// In Fortran
+extern void* c_new_point(float x, float y);
+extern void c_set_x(void* p, float x);
+extern float c_get_x(void* p);
+extern void c_delete_point(void* p);
+
+#endif // VECF_H_

--- a/examples/bindc/pyclass_opaque/point.h
+++ b/examples/bindc/pyclass_opaque/point.h
@@ -1,13 +1,13 @@
 #ifndef VECF_H_
 #define VECF_H_
 
-#include<stdio.h>
-#include<stdlib.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 // In Fortran
-extern void* c_new_point(float x, float y);
-extern void c_set_x(void* p, float x);
-extern float c_get_x(void* p);
-extern void c_delete_point(void* p);
+extern void *c_new_point(float x, float y);
+extern void c_set_x(void *p, float x);
+extern float c_get_x(void *p);
+extern void c_delete_point(void *p);
 
 #endif // VECF_H_

--- a/examples/bindc/pyclass_opaque/point.h
+++ b/examples/bindc/pyclass_opaque/point.h
@@ -4,10 +4,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-// In Fortran
-extern void *c_new_point(float x, float y);
-extern void c_set_x(void *p, float x);
-extern float c_get_x(void *p);
-extern void c_delete_point(void *p);
+/* In Fortran */
+extern void *c_new_point(double x, double y);
+extern void c_delete_point(void **point);
+extern double c_get_x(void *point);
+extern void c_set_x(void *point, double x);
+extern double c_get_y(void *point);
+extern void c_set_y(void *point, double y);
 
-#endif // VECF_H_
+
+#endif

--- a/examples/bindc/pyclass_opaque/pointcapsule.c
+++ b/examples/bindc/pyclass_opaque/pointcapsule.c
@@ -1,0 +1,166 @@
+#ifndef PY_SSIZE_T_CLEAN
+#define PY_SSIZE_T_CLEAN
+#include <stdio.h>
+#endif /* PY_SSIZE_T_CLEAN */
+
+#include "Python.h"
+#include "structmember.h"
+/* #include "point.h" */
+
+#include <Python.h>
+
+// Forward declarations for the Fortran functions
+extern void *c_new_point(double x, double y);
+extern void c_delete_point(void **point);
+extern double c_get_x(void *point);
+extern void c_set_x(void *point, double x);
+extern double c_get_y(void *point);
+extern void c_set_y(void *point, double y);
+
+// Destructor for the Python capsule
+void point_capsule_destructor(PyObject *capsule) {
+  void *point = PyCapsule_GetPointer(capsule, "point._Point");
+  if (point) {
+    c_delete_point(&point);
+  }
+}
+
+// Point object definition
+typedef struct {
+  PyObject_HEAD PyObject *capsule; // Capsule containing the Point pointer
+} PyPointObject;
+
+// Deallocates the PyPointObject
+static void PyPoint_dealloc(PyPointObject *self) {
+  Py_XDECREF(
+      self->capsule); // This will trigger the destructor if refcount reaches 0
+  Py_TYPE(self)->tp_free((PyObject *)self);
+}
+
+// Creates a new PyPointObject
+static PyObject *PyPoint_new(PyTypeObject *type, PyObject *args,
+                             PyObject *kwds) {
+  double x, y;
+  if (!PyArg_ParseTuple(args, "dd", &x, &y)) {
+    return NULL;
+  }
+
+  PyPointObject *self = (PyPointObject *)type->tp_alloc(type, 0);
+  if (self != NULL) {
+    void *point = c_new_point(x, y);
+    if (point == NULL) {
+      Py_DECREF(self);
+      return PyErr_NoMemory();
+    }
+    self->capsule =
+        PyCapsule_New(point, "point._Point", point_capsule_destructor);
+    if (self->capsule == NULL) {
+      c_delete_point(
+          &point); // Clean up Fortran point since capsule creation failed
+      Py_DECREF(self);
+      return NULL;
+    }
+  }
+  return (PyObject *)self;
+}
+
+// Getter for the 'x' attribute
+static PyObject *PyPoint_getx(PyPointObject *self, void *closure) {
+  void *point = PyCapsule_GetPointer(self->capsule, "point._Point");
+  double x = c_get_x(&point);
+  return PyFloat_FromDouble(x);
+}
+
+// Setter for the 'x' attribute
+static int PyPoint_setx(PyPointObject *self, PyObject *value, void *closure) {
+  if (value == NULL) {
+    PyErr_SetString(PyExc_TypeError, "Cannot delete the x attribute");
+    return -1;
+  }
+  if (!PyFloat_Check(value)) {
+    PyErr_SetString(PyExc_TypeError, "The x attribute value must be a float");
+    return -1;
+  }
+  double x = PyFloat_AsDouble(value);
+  void *point = PyCapsule_GetPointer(self->capsule, "point._Point");
+  c_set_x(&point, x);
+  return 0;
+}
+
+// Getter for the 'y' attribute
+static PyObject *PyPoint_gety(PyPointObject *self, void *closure) {
+  void *point = PyCapsule_GetPointer(self->capsule, "point._Point");
+  double y = c_get_y(&point);
+  return PyFloat_FromDouble(y);
+}
+
+// Setter for the 'y' attribute
+static int PyPoint_sety(PyPointObject *self, PyObject *value, void *closure) {
+  if (value == NULL) {
+    PyErr_SetString(PyExc_TypeError, "Cannot delete the y attribute");
+    return -1;
+  }
+  if (!PyFloat_Check(value)) {
+    PyErr_SetString(PyExc_TypeError, "The y attribute value must be a float");
+    return -1;
+  }
+  double y = PyFloat_AsDouble(value);
+  void *point = PyCapsule_GetPointer(self->capsule, "point._Point");
+  c_set_y(&point, y);
+  return 0;
+}
+
+// Define the properties of the Point type
+static PyGetSetDef PyPoint_getseters[] = {
+    {"x", (getter)PyPoint_getx, (setter)PyPoint_setx, "x coordinate", NULL},
+    {"y", (getter)PyPoint_gety, (setter)PyPoint_sety, "y coordinate", NULL},
+    {NULL} /* Sentinel */
+};
+
+// Initializes the PyPointType object
+static PyTypeObject PyPointType = {
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "point.Point",
+    .tp_doc = "Point objects",
+    .tp_basicsize = sizeof(PyPointObject),
+    .tp_itemsize = 0,
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    .tp_new = PyPoint_new,
+    .tp_dealloc = (destructor)PyPoint_dealloc,
+    .tp_getset = PyPoint_getseters,
+    // Additional fields can be filled in as needed
+};
+
+// Define the methods of the module if there are any
+static PyMethodDef point_methods[] = {
+    // Methods can be added here if needed
+    {NULL, NULL, 0, NULL} /* Sentinel */
+};
+
+// Initializes the point module
+static PyModuleDef pointmodule = {
+    PyModuleDef_HEAD_INIT,
+    .m_name = "point",
+    .m_doc = "Module that provides a Point object.",
+    .m_size = -1,
+    .m_methods = point_methods,
+};
+
+PyMODINIT_FUNC PyInit_point(void) {
+  if (PyType_Ready(&PyPointType) < 0) {
+    return NULL;
+  }
+
+  PyObject *m = PyModule_Create(&pointmodule);
+  if (m == NULL) {
+    return NULL;
+  }
+
+  Py_INCREF(&PyPointType);
+  if (PyModule_AddObject(m, "Point", (PyObject *)&PyPointType) < 0) {
+    Py_DECREF(&PyPointType);
+    Py_DECREF(m);
+    return NULL;
+  }
+
+  return m;
+}

--- a/examples/bindc/pyclass_opaque/readme.org
+++ b/examples/bindc/pyclass_opaque/readme.org
@@ -1,0 +1,28 @@
+* About
+This is meant to demonstrate the implementation of a simple derived type which
+is ~bind(c)~ compatible in the form of a new type. This implementation is in
+theory not strongly linked to the implementation within Fortran, and might
+eventually be used for regular Fortran types.
+
+However, this is complicated enough to work in two stages. First there is a
+basic implementation in C-Python in the ~cpython~ folder. Followed by a fortran
+implementation, which will then be mapped into a Python implementaiton.
+
+** Usage
+#+begin_src bash
+meson setup bbdir
+meson compile -C bbdir
+python -c "import bbdir.pycart as pycart; aak = pycart.pycart(1,10,2); print(aak); aak.unitstep(); print(aak)"
+pycart(x: 1.000000, y: 10.000000, z: 2.000000)
+ Modifying derived type
+pycart(x: 2.000000, y: 11.000000, z: 3.000000)
+#+end_src
+
+Look into generating a wrapper in Fortran which would then be manipulated via pointers on the C side.
+
+*** Tasks
+- What about other compilers?
+- Look at approaches for non-bind(c) variants
+- Extend the Python members with a pointer to the object
+  - Without ~bind(c)~
+- Allocate memory and use pointers with ~bind(c)~ as well

--- a/examples/bindc/pyclass_opaque/testc.c
+++ b/examples/bindc/pyclass_opaque/testc.c
@@ -1,0 +1,38 @@
+#include <stdio.h>
+
+// Assuming the Fortran functions have been declared with bind(C)
+// and their names are unchanged in the linking process
+
+// Declarations of Fortran functions
+extern void *c_new_point(double x, double y);
+extern void c_delete_point(void **p);
+extern double c_get_x(void **p);
+extern void c_set_x(void **p, double x);
+extern double c_get_y(void **p);
+extern void c_set_y(void **p, double y);
+
+int main() {
+  // Create a new point using the Fortran function
+  void *point = c_new_point(3.0, 4.0);
+  if (point == NULL) {
+    fprintf(stderr, "Failed to create point\n");
+    return 1;
+  }
+  /* Retrieve the x and y values using the Fortran function */
+  double x = c_get_x(&point);
+  double y = c_get_y(&point);
+
+  printf("Point coordinates: x = %f, y = %f\n", x, y);
+
+  /* Set the x and y values using the Fortran function */
+  c_set_x(&point, 5.0);
+  c_set_y(&point, 6.0);
+
+  printf("Point coordinates after set: x = %f, y = %f\n", c_get_x(&point),
+         c_get_y(&point));
+
+  // Clean up and delete the point using the Fortran function
+  c_delete_point(&point);
+
+  return 0;
+}

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,0 +1,540 @@
+metadata:
+  content_hash:
+    linux-64: e90c2ee71ad70fc0a1c8302029533a7d1498f2bffcd0eaa8d2934700e775dc1d
+  channels:
+  - url: https://conda.anaconda.org/conda-forge/
+    used_env_vars: []
+  platforms:
+  - linux-64
+  sources: []
+  time_metadata: null
+  git_metadata: null
+  inputs_metadata: null
+  custom_metadata: null
+package:
+- platform: linux-64
+  name: _libgcc_mutex
+  version: '0.1'
+  category: main
+  manager: conda
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  hash:
+    md5: d7c89558ba9fa0495403155b64376d81
+    sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+  build: conda_forge
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: None
+  size: 2562
+  timestamp: 1578324546067
+- platform: linux-64
+  name: _openmp_mutex
+  version: '4.5'
+  category: main
+  manager: conda
+  dependencies:
+  - _libgcc_mutex 0.1 conda_forge
+  - libgomp >=7.5.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+  hash:
+    md5: 73aaf86a425cc6e73fcf236a5a46396d
+    sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+  build: 2_gnu
+  arch: x86_64
+  subdir: linux-64
+  build_number: 16
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23621
+  timestamp: 1650670423406
+- platform: linux-64
+  name: bzip2
+  version: 1.0.8
+  category: main
+  manager: conda
+  dependencies:
+  - libgcc-ng >=9.3.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h7f98852_4.tar.bz2
+  hash:
+    md5: a1fd65c7ccbf10880423d82bca54eb54
+    sha256: cb521319804640ff2ad6a9f118d972ed76d86bea44e5626c09a13d38f562e1fa
+  build: h7f98852_4
+  arch: x86_64
+  subdir: linux-64
+  build_number: 4
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 495686
+  timestamp: 1606604745109
+- platform: linux-64
+  name: ca-certificates
+  version: 2023.7.22
+  category: main
+  manager: conda
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.7.22-hbcca054_0.conda
+  hash:
+    md5: a73ecd2988327ad4c8f2c331482917f2
+    sha256: 525b7b6b5135b952ec1808de84e5eca57c7c7ff144e29ef3e96ae4040ff432c1
+  build: hbcca054_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: ISC
+  size: 149515
+  timestamp: 1690026108541
+- platform: linux-64
+  name: configargparse
+  version: '1.7'
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.5
+  url: https://conda.anaconda.org/conda-forge/noarch/configargparse-1.7-pyhd8ed1ab_0.conda
+  hash:
+    md5: 0d07dc29b1c1cc973f76b74beb44915f
+    sha256: 23f7283b59d20a895c5fa41aa5d276155cedf257418db7f952d615d6a2e5fa43
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 39491
+  timestamp: 1690138171226
+- platform: linux-64
+  name: fprettify
+  version: 0.3.7
+  category: main
+  manager: conda
+  dependencies:
+  - configargparse
+  - python >=3.5
+  url: https://conda.anaconda.org/conda-forge/noarch/fprettify-0.3.7-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 153742a29b4c22ee54442fb93a0e9127
+    sha256: d3242d15d46b7c101b468859e4c6d63b867e24b5f05f0afacc29945a4ee24aa8
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: GPL-3.0-or-later
+  license_family: GPL
+  noarch: python
+  size: 137690
+  timestamp: 1637859635697
+- platform: linux-64
+  name: ld_impl_linux-64
+  version: '2.40'
+  category: main
+  manager: conda
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
+  hash:
+    md5: 7aca3059a1729aa76c597603f10b0dd3
+    sha256: f6cc89d887555912d6c61b295d398cff9ec982a3417d38025c45d5dd9b9e79cd
+  build: h41732ed_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  constrains:
+  - binutils_impl_linux-64 2.40
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 704696
+  timestamp: 1674833944779
+- platform: linux-64
+  name: libexpat
+  version: 2.5.0
+  category: main
+  manager: conda
+  dependencies:
+  - libgcc-ng >=12
+  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.5.0-hcb278e6_1.conda
+  hash:
+    md5: 6305a3dd2752c76335295da4e581f2fd
+    sha256: 74c98a563777ae2ad71f1f74d458a8ab043cee4a513467c159ccf159d0e461f3
+  build: hcb278e6_1
+  arch: x86_64
+  subdir: linux-64
+  build_number: 1
+  constrains:
+  - expat 2.5.0.*
+  license: MIT
+  license_family: MIT
+  size: 77980
+  timestamp: 1680190528313
+- platform: linux-64
+  name: libffi
+  version: 3.4.2
+  category: main
+  manager: conda
+  dependencies:
+  - libgcc-ng >=9.4.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+  hash:
+    md5: d645c6d2ac96843a2bfaccd2d62b3ac3
+    sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
+  build: h7f98852_5
+  arch: x86_64
+  subdir: linux-64
+  build_number: 5
+  license: MIT
+  license_family: MIT
+  size: 58292
+  timestamp: 1636488182923
+- platform: linux-64
+  name: libgcc-ng
+  version: 13.2.0
+  category: main
+  manager: conda
+  dependencies:
+  - _libgcc_mutex 0.1 conda_forge
+  - _openmp_mutex >=4.5
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_2.conda
+  hash:
+    md5: c28003b0be0494f9a7664389146716ff
+    sha256: d361d3c87c376642b99c1fc25cddec4b9905d3d9b9203c1c545b8c8c1b04539a
+  build: h807b86a_2
+  arch: x86_64
+  subdir: linux-64
+  build_number: 2
+  constrains:
+  - libgomp 13.2.0 h807b86a_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 771133
+  timestamp: 1695219384393
+- platform: linux-64
+  name: libgomp
+  version: 13.2.0
+  category: main
+  manager: conda
+  dependencies:
+  - _libgcc_mutex 0.1 conda_forge
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_2.conda
+  hash:
+    md5: e2042154faafe61969556f28bade94b9
+    sha256: e1e82348f8296abfe344162b3b5f0ddc2f504759ebeb8b337ba99beaae583b15
+  build: h807b86a_2
+  arch: x86_64
+  subdir: linux-64
+  build_number: 2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 421133
+  timestamp: 1695219303065
+- platform: linux-64
+  name: libnsl
+  version: 2.0.1
+  category: main
+  manager: conda
+  dependencies:
+  - libgcc-ng >=12
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+  hash:
+    md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
+    sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
+  build: hd590300_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: LGPL-2.1-only
+  license_family: GPL
+  size: 33408
+  timestamp: 1697359010159
+- platform: linux-64
+  name: libsqlite
+  version: 3.44.0
+  category: main
+  manager: conda
+  dependencies:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.44.0-h2797004_0.conda
+  hash:
+    md5: b58e6816d137f3aabf77d341dd5d732b
+    sha256: 74ef5dcb900c38bec53140036e5e2a9cc7ffcd806da479ea2305f962a358a259
+  build: h2797004_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: Unlicense
+  size: 845977
+  timestamp: 1698854720770
+- platform: linux-64
+  name: libstdcxx-ng
+  version: 13.2.0
+  category: main
+  manager: conda
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_2.conda
+  hash:
+    md5: 9172c297304f2a20134fc56c97fbe229
+    sha256: ab22ecdc974cdbe148874ea876d9c564294d5eafa760f403ed4fd495307b4243
+  build: h7e041cc_2
+  arch: x86_64
+  subdir: linux-64
+  build_number: 2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 3842773
+  timestamp: 1695219454837
+- platform: linux-64
+  name: libuuid
+  version: 2.38.1
+  category: main
+  manager: conda
+  dependencies:
+  - libgcc-ng >=12
+  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+  hash:
+    md5: 40b61aab5c7ba9ff276c41cfffe6b80b
+    sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
+  build: h0b41bf4_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33601
+  timestamp: 1680112270483
+- platform: linux-64
+  name: libzlib
+  version: 1.2.13
+  category: main
+  manager: conda
+  dependencies:
+  - libgcc-ng >=12
+  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
+  hash:
+    md5: f36c115f1ee199da648e0597ec2047ad
+    sha256: 370c7c5893b737596fd6ca0d9190c9715d89d888b8c88537ae1ef168c25e82e4
+  build: hd590300_5
+  arch: x86_64
+  subdir: linux-64
+  build_number: 5
+  constrains:
+  - zlib 1.2.13 *_5
+  license: Zlib
+  license_family: Other
+  size: 61588
+  timestamp: 1686575217516
+- platform: linux-64
+  name: meson
+  version: 1.2.3
+  category: main
+  manager: conda
+  dependencies:
+  - ninja >=1.8.2
+  - python >=3.5.2
+  - setuptools
+  url: https://conda.anaconda.org/conda-forge/noarch/meson-1.2.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 884e718cb42b3dbdf07f0ebea32ccacd
+    sha256: 8781b90ae65e1e982a7a28850567630d3f5b6b9c4a88cd9aa3f8a7a4971991e2
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: Apache-2.0
+  license_family: APACHE
+  noarch: python
+  size: 618539
+  timestamp: 1697868378316
+- platform: linux-64
+  name: ncurses
+  version: '6.4'
+  category: main
+  manager: conda
+  dependencies:
+  - libgcc-ng >=12
+  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-h59595ed_2.conda
+  hash:
+    md5: 7dbaa197d7ba6032caf7ae7f32c1efa0
+    sha256: 91cc03f14caf96243cead96c76fe91ab5925a695d892e83285461fb927dece5e
+  build: h59595ed_2
+  arch: x86_64
+  subdir: linux-64
+  build_number: 2
+  license: X11 AND BSD-3-Clause
+  size: 884434
+  timestamp: 1698751260967
+- platform: linux-64
+  name: ninja
+  version: 1.11.1
+  category: main
+  manager: conda
+  dependencies:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  url: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.11.1-h924138e_0.conda
+  hash:
+    md5: 73a4953a2d9c115bdc10ff30a52f675f
+    sha256: b555247ac8859b4ff311e3d708a0640f1bfe9fae7125c485b444072474a84c41
+  build: h924138e_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  size: 2251263
+  timestamp: 1676837602636
+- platform: linux-64
+  name: openssl
+  version: 3.1.4
+  category: main
+  manager: conda
+  dependencies:
+  - ca-certificates
+  - libgcc-ng >=12
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.1.4-hd590300_0.conda
+  hash:
+    md5: 412ba6938c3e2abaca8b1129ea82e238
+    sha256: d15b3e83ce66c6f6fbb4707f2f5c53337124c01fb03bfda1cf25c5b41123efc7
+  build: hd590300_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  constrains:
+  - pyopenssl >=22.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 2648006
+  timestamp: 1698164814626
+- platform: linux-64
+  name: python
+  version: 3.12.0
+  category: main
+  manager: conda
+  dependencies:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libnsl >=2.0.0,<2.1.0a0
+  - libsqlite >=3.43.0,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.1.3,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.0-hab00c5b_0_cpython.conda
+  hash:
+    md5: 7f97faab5bebcc2580f4f299285323da
+    sha256: 5398ebae6a1ccbfd3f76361eac75f3ac071527a8072627c4bf9008c689034f48
+  build: hab00c5b_0_cpython
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  constrains:
+  - python_abi 3.12.* *_cp312
+  license: Python-2.0
+  size: 32123473
+  timestamp: 1696324522323
+- platform: linux-64
+  name: readline
+  version: '8.2'
+  category: main
+  manager: conda
+  dependencies:
+  - libgcc-ng >=12
+  - ncurses >=6.3,<7.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+  hash:
+    md5: 47d31b792659ce70f470b5c82fdfb7a4
+    sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
+  build: h8228510_1
+  arch: x86_64
+  subdir: linux-64
+  build_number: 1
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 281456
+  timestamp: 1679532220005
+- platform: linux-64
+  name: setuptools
+  version: 68.2.2
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.7
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: fc2166155db840c634a1291a5c35a709
+    sha256: 851901b1f8f2049edb36a675f0c3f9a98e1495ef4eb214761b048c6f696a06f7
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 464399
+  timestamp: 1694548452441
+- platform: linux-64
+  name: tk
+  version: 8.6.13
+  category: main
+  manager: conda
+  dependencies:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-h2797004_0.conda
+  hash:
+    md5: 513336054f884f95d9fd925748f41ef3
+    sha256: 679e944eb93fde45d0963a22598fafacbb429bb9e7ee26009ba81c4e0c435055
+  build: h2797004_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: TCL
+  license_family: BSD
+  size: 3290187
+  timestamp: 1695506262576
+- platform: linux-64
+  name: tzdata
+  version: 2023c
+  category: main
+  manager: conda
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+  hash:
+    md5: 939e3e74d8be4dac89ce83b20de2492a
+    sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
+  build: h71feb2d_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: LicenseRef-Public-Domain
+  noarch: generic
+  size: 117580
+  timestamp: 1680041306008
+- platform: linux-64
+  name: xz
+  version: 5.2.6
+  category: main
+  manager: conda
+  dependencies:
+  - libgcc-ng >=12
+  url: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+  hash:
+    md5: 2161070d867d1b1204ea749c8eec4ef0
+    sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
+  build: h166bdaf_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: LGPL-2.1 and GPL-2.0
+  size: 418368
+  timestamp: 1660346797927
+version: 1

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,14 @@
+[project]
+name = "f2py_derived_nep"
+version = "0.1.0"
+description = "Add a short description here"
+authors = ["Rohit Goswami <rog32@hi.is>"]
+channels = ["conda-forge"]
+platforms = ["linux-64"]
+
+[tasks]
+
+[dependencies]
+fprettify = "0.3.7.*"
+meson = "1.2.3.*"
+ninja = "1.11.1.*"


### PR DESCRIPTION
This is a more general approach, allowing for types which are not necessarily bound by the constraints of `bind(c)` because the Fortran code handles everything, only pointers (compatible ones) are exposed to the Python code. This needs a lot of wrappers, but it is thus ideal for `f2py`.